### PR TITLE
fix(test): TradeLegControllerTest - TradeLegControllerTest.testCreate…

### DIFF
--- a/backend/src/main/java/com/technicalchallenge/dto/TradeLegDTO.java
+++ b/backend/src/main/java/com/technicalchallenge/dto/TradeLegDTO.java
@@ -19,7 +19,8 @@ public class TradeLegDTO {
     private Long legId;
 
     @NotNull(message = "Notional is required")
-    @Positive(message = "Notional must be positive")
+    //FOLA REMOVED the code line below to resolve validation conflict and handle it in controller manually
+    //@Positive(message = "Notional must be positive")
     private BigDecimal notional;
 
     private Double rate;

--- a/backend/src/test/java/com/technicalchallenge/controller/TradeLegControllerTest.java
+++ b/backend/src/test/java/com/technicalchallenge/controller/TradeLegControllerTest.java
@@ -164,7 +164,7 @@ public class TradeLegControllerTest {
                 .content(objectMapper.writeValueAsString(tradeLegDTO)))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string("Notional must be positive"));
-
+                
         verify(tradeLegService, never()).saveTradeLeg(any(TradeLeg.class), any(TradeLegDTO.class));
     }
 


### PR DESCRIPTION
…TradeLegValidationFailure_NegativeNotional

- Problem: The test failure Response content expected:Notional must be positive but was:null means your controller returned a 400 Bad Request as expected, but the response body was empty instead of containing the error message Notional must be positive

-Root Cause: There is a validation conflict: there is an annotation validation @Positive in the TradeLegDTO and then there is also a manual validation check in the TradeLegController class using an if statement.

-Solution: I removed the validation annotation in the TradeLegDTO.notional to rely solely on the controller logic. This way, the code will return the custom error message: Notional must be positive

-Impact: This ensures the code flow proceeds to the manual validation check in TradeLegController, guaranteeing the return of the expected error string.